### PR TITLE
Delete unused wires in XT2IDE.

### DIFF
--- a/rtl/KFPC-XT/HDL/Peripherals.sv
+++ b/rtl/KFPC-XT/HDL/Peripherals.sv
@@ -988,7 +988,6 @@ module PERIPHERALS #(
     logic           ide0_io_read_n;
     logic           ide0_io_write_n;
     logic   [2:0]   ide0_address;
-    logic           ide0_data_bus_io;
     logic   [15:0]  ide0_data_bus_in;
     logic   [15:0]  ide0_data_bus_out;
 
@@ -1012,7 +1011,6 @@ module PERIPHERALS #(
         .ide_io_write_n     (ide0_io_write_n),
 
         .ide_address        (ide0_address),
-        .ide_data_bus_io    (ide0_data_bus_io),
         .ide_data_bus_in    (ide0_data_bus_in),
         .ide_data_bus_out   (ide0_data_bus_out)
     );

--- a/rtl/KFPC-XT/HDL/XT2IDE.sv
+++ b/rtl/KFPC-XT/HDL/XT2IDE.sv
@@ -22,7 +22,6 @@ module XT2IDE
     output  logic           ide_io_write_n,
 
     output  logic   [2:0]   ide_address,
-    output  logic           ide_data_bus_io,
     input   logic   [15:0]  ide_data_bus_in,
     output  logic   [15:0]  ide_data_bus_out
 );
@@ -43,14 +42,12 @@ module XT2IDE
     always_comb
     begin
         latch_high_read_byte    = 1'b0;
-        ide_data_bus_io         = 1'b1;
         read_high_byte          = 1'b0;
         latch_high_write_byte   = 1'b0;
 
         if (~address[2] & ~address[1] & ~select_2 & ~chip_select_n) begin
             casez ({select_1, io_read_n, io_write_n})
                 3'b001: latch_high_read_byte    = 1'b1;
-                3'b010: ide_data_bus_io         = 1'b0;
                 3'b101: read_high_byte          = 1'b1;
                 3'b110: latch_high_write_byte   = 1'b1;
             endcase


### PR DESCRIPTION
Delete ide0_data_bus_io as it is not in use.