### PR TITLE
Fixed timer output in mode 3.

### DIFF
--- a/rtl/KFPC-XT/HDL/KF8253/HDL/KF8253_Counter.sv
+++ b/rtl/KFPC-XT/HDL/KF8253/HDL/KF8253_Counter.sv
@@ -53,6 +53,8 @@ module KF8253_Counter (
 
     logic           start_counting;
 
+    logic           first_count_edge;
+
     logic   [16:0]  count_next;
     logic           count_period;
     logic           prev_count_period;
@@ -285,6 +287,18 @@ module KF8253_Counter (
             start_counting <= start_counting;
     end
 
+    // First counte edge signal
+    always_ff @(posedge clock, posedge reset) begin
+        if (reset)
+            first_count_edge    <= 1'b0;
+        else if (start_counting==1'b0)
+            first_count_edge    <= 1'b1;
+        else if (count_edge == 1'b1)
+            first_count_edge    <= 1'b0;
+        else
+            first_count_edge    <= first_count_edge;
+    end
+
     // Decrement counter
     function logic [16:0] decrement (input [16:0] count, input is_bcd);
         if (count == 17'b0_0000_0000_0000_0000)
@@ -372,7 +386,7 @@ module KF8253_Counter (
                     count_next = count;
 
                 if (count_next == 17'b0_0000_0000_0000_0000) begin
-                    count_period = 1'b1;
+                    count_period = 1'b1 & ~first_count_edge;
                     count_next = count_preset_load;
                 end
 


### PR DESCRIPTION
The Timer out output was changing to LOW as soon as the Timer count started in Mode 3.
This caused the time between the start of the count and the interrupt to be shortened when using Mode 3.